### PR TITLE
aos-rcar-gen4.yaml: adapt to moulin changes

### DIFF
--- a/application_cpu/aos-rcar-gen4.yaml
+++ b/application_cpu/aos-rcar-gen4.yaml
@@ -359,4 +359,4 @@ parameters:
       overrides:
         variables:
           MACHINE: "s4sk"
-          META_RENESAS_COMMIT: "fb473de"
+          META_RENESAS_COMMIT: "fb473def"


### PR DESCRIPTION
The current build system is using the head revision of the moulin build tool.

Recently, a set of fixes was applied to that repository. One of them contains the following change:

https://github.com/xen-troops/moulin/commit/19d2ec09c4368df251b2593795c85e95f9d8e87a

That patch checks whether yaml contains source directives for the git fetcher, which contain the same repository but different branches or commit ids. Such condition leads to a build error.

In our case, the built yaml file 'aos-rcar-gen4-wb.yaml' has such a situation:

META_RENESAS_COMMIT: "fb473de"
...
- type: git url: https://github.com/renesas-rcar/meta-renesas.git rev: "%{META_RENESAS_COMMIT}" ...
- type: git url: https://github.com/renesas-rcar/meta-renesas.git rev: "fb473def"

This is causing the following error:
moulin.yaml_helpers.YAMLProcessingError: ERROR:
Repository https://github.com/renesas-rcar/meta-renesas.git has two
revisions 'fb473def' and 'fb473de'   in "./aos-rcar-gen4-wb.yaml",
line 243, column 14

'aos-rcar-gen4-wb.yaml' file is generated during the build and based on the 'aos-rcar-gen4.yaml'.

This patch normalizes the commit id-s, which are used in the yaml file, to avoid a build error.