### PR TITLE
README: Update link to repo_init.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please refer to the official webpage:
 # Download repository
 Execute the following command:
 
-	bash -c "$(wget -O- https://raw.github.com/renesas-rcar/whitebox-sdk/v5.4/tool/repo_init.sh )"
+	bash -c "$(wget -O- https://raw.githubusercontent.com/renesas-rcar/whitebox-sdk/v5.4/tool/repo_init.sh )"
 
 # Required packages
 


### PR DESCRIPTION
The URL was changed:
-raw.github.com
+raw.githubusercontent.com

This updates to avoid download error:

```
$ wget -O- https://raw.github.com/renesas-rcar/whitebox-sdk/v5.4/tool/repo_init.sh
--2025-09-19 14:44:31--  https://raw.github.com/renesas-rcar/whitebox-sdk/v5.4/tool/repo_init.sh
Resolving raw.github.com (raw.github.com)... 185.199.110.133, 185.199.109.133, 185.199.108.133, ...
Connecting to raw.github.com (raw.github.com)|185.199.110.133|:443... connected.
HTTP request sent, awaiting response... 503 hostname doesn't match against certificate
2025-09-19 14:44:32 ERROR 503: hostname doesn't match against certificate.
```